### PR TITLE
[OPS-29] Full node logging to app insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ The full node is run in exactly the same way as the standard Strax full node.
 * **DEVNET** - `dotnet run -devmode=miner`
 * **TESTNET** - `dotnet run -testnet`
 * **MAINNET** - `dotnet run`
+
+## Configuration
+
+The node is configured to log to application insights, providing an instrumentation key is provided. The instrumentation key can be provided in the `configuration.json` settings, user-secrets or environment variables.

--- a/src/Opdex.Cirrus/Opdex.Cirrus.csproj
+++ b/src/Opdex.Cirrus/Opdex.Cirrus.csproj
@@ -1,11 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <UserSecretsId>493b6377-1780-46b1-8d27-93aed570ab63</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.NLogTarget" Version="2.18.0" />
     <PackageReference Include="Stratis.Features.Api" Version="1.0.9.4" />
     <PackageReference Include="Stratis.Features.Collateral" Version="4.0.1" />
     <PackageReference Include="Stratis.Features.Notifications" Version="1.0.9.4" />

--- a/src/Opdex.Cirrus/configuration.json
+++ b/src/Opdex.Cirrus/configuration.json
@@ -1,0 +1,7 @@
+{
+    "Azure": {
+        "AppInsights": {
+            "InstrumentationKey": ""
+        }
+    }
+}


### PR DESCRIPTION
Sets up full node logging to app insights.

For now I've set it up to only log warnings. We may want to configure info logging for some features/classes which can be configured later on, although I'm thinking this will be easier when it's fully set up. And we can modify log levels depending on the network.